### PR TITLE
Improve search. Fix styling.

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <title>Anime Facts</title>
 </head>
 <body>
+    <div id="pageWrapper">
     <header id="header">
         <div class="wrapper">
             <div class="headerFlexContainer">
@@ -26,7 +27,7 @@
         </div>
     </header>
 
-    <main>
+    <main id="main">
         <div class="wrapper">
             <section class="intro">
                 <h1>TIL Anime Facts</h1>
@@ -55,6 +56,7 @@
             </div>
         </div>
     </footer>
+    </div>
     <script src="./script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -12,18 +12,28 @@ animeApp.sendInput = ()=>{
 animeApp.getAnimeData = (userInput) => {
     const url = new URL(`https://api.jikan.moe/v4/anime`)
     url.search = new URLSearchParams({
-        q: userInput.toString(),
-        limit: 4,
+        letter: userInput.trim().toString(),
+        // q doesn't work with order_by or sort
+        order_by: "popularity",
+        sort: "asc",
+        // Remove NSFW materials Note: sfw param not working w/ q
+        genres_exclude: 12,
+        limit: 12,
     })
     fetch(url)
     .then((res) => res.json())
     .then((animeData) => {
         console.log(animeData);
         animeApp.displayElement(animeData.data);
+        // addSpacer() needs to be add at the bottom
+        animeApp.addSpacer();
     })
 }
 
 animeApp.displayElement = (dataObjectFromApi) => {
+    // Reseting the result at each new entry
+    const resultElement = document.querySelector(".results");
+    resultElement.innerHTML = "";
 
     dataObjectFromApi.forEach(anime => {
         // creating the li element
@@ -36,7 +46,7 @@ animeApp.displayElement = (dataObjectFromApi) => {
 
         const imageElement = document.createElement('img');
         imageElement.src = anime.images.jpg.image_url;
-        imageElement.alt =  `image of  ${anime.title}` ;
+        imageElement.alt =  `image of  ${anime.title}`;
 
         // now need to append title and img to the li element
         listElement.appendChild(titleElement);
@@ -47,9 +57,15 @@ animeApp.displayElement = (dataObjectFromApi) => {
     });
 }
 
+// Add a spacer to provide a height foot print to seperate the result section from the footer section
+animeApp.addSpacer = ()=>{
+    const spacerElement = document.createElement('div');
+    spacerElement.classList.add("spacer");
+    document.querySelector(".results").appendChild(spacerElement);
+}
+
 animeApp.init = ()=>{
     animeApp.sendInput();
-    // animeApp.getInput();
 };
 
 animeApp.init();

--- a/styles/sass/partials/_baseStyles.scss
+++ b/styles/sass/partials/_baseStyles.scss
@@ -1,6 +1,12 @@
-
 html {
     background-color: $solidWhite;
+}
+
+#pageWrapper {
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    min-height: 100vh;
 }
 
 .wrapper {

--- a/styles/sass/partials/_footer.scss
+++ b/styles/sass/partials/_footer.scss
@@ -1,11 +1,18 @@
 footer {
+    display: flex;
     background-color: $primaryColorL;
     color: $solidWhite;
     padding: 2% 0;
-    // position: absolute;
-    // bottom: 0;
+    // Footer stay absolute to the pageWrapper div (in baseStyles) which has a min-height : 100vh. The combined effects allow footer to stay fixed at the bottom regardless of the page height.
+    position: absolute;
+    bottom: 0;
     width: 100%;
+    height: 6rem;
     .footerGridContainer {
+        position: relative;
+        // Fix gap at the bottom of footer on wide screen
+        align-self: center;
+        margin: 0 auto;
         display: grid;
         grid-template-columns: 1fr 1fr;
         justify-items: center;

--- a/styles/sass/partials/_section.scss
+++ b/styles/sass/partials/_section.scss
@@ -23,7 +23,6 @@ section {
         border-radius: 15px;
         background-color: $primaryColorL;
         
-
         // need the children of the list to also be a flex item
         display: flex;
         flex-direction: column;
@@ -42,6 +41,13 @@ section {
     
     img {
         min-height: 350px;
+        min-width: fit-content;
+        border-radius: 20px;
     }
 
+}
+
+.spacer {
+    height: 6rem; // The same height of the footer element
+    width: 100%;
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -15,7 +15,7 @@ article, aside, footer, header, nav, section {
 
 h1 {
   font-size: 2em;
-  margin: 0.67em 0;
+  margin: .67em 0;
 }
 
 figcaption, figure, main {
@@ -34,7 +34,7 @@ hr {
 }
 
 pre {
-  font-family: monospace, monospace;
+  font-family: monospace,monospace;
   font-size: 1em;
 }
 
@@ -59,7 +59,7 @@ b, strong {
 }
 
 code, kbd, samp {
-  font-family: monospace, monospace;
+  font-family: monospace,monospace;
   font-size: 1em;
 }
 
@@ -84,11 +84,11 @@ sub, sup {
 }
 
 sub {
-  bottom: -0.25em;
+  bottom: -.25em;
 }
 
 sup {
-  top: -0.5em;
+  top: -.5em;
 }
 
 audio, video {
@@ -137,7 +137,7 @@ button:-moz-focusring, [type=button]:-moz-focusring, [type=reset]:-moz-focusring
 }
 
 fieldset {
-  padding: 0.35em 0.75em 0.625em;
+  padding: .35em .75em .625em;
 }
 
 legend {
@@ -207,7 +207,7 @@ template {
   visibility: hidden;
   display: block;
   font-size: 0;
-  content: "";
+  content: '';
   clear: both;
   height: 0;
 }
@@ -249,7 +249,7 @@ body, h1, h2, h3, h4, p, figure, blockquote, dl, dd {
 }
 
 /* Remove list styles on ul, ol elements with a list role, which suggests default styling will be removed */
-ul[role=list], ol[role=list] {
+ul[role='list'], ol[role='list'] {
   list-style: none;
 }
 
@@ -267,8 +267,7 @@ body {
 
 /* A elements that don't have a class get default styles */
 a:not([class]) {
-  -webkit-text-decoration-skip: ink;
-          text-decoration-skip-ink: auto;
+  text-decoration-skip-ink: auto;
 }
 
 /* Make images easier to work with */
@@ -287,7 +286,6 @@ input, button, textarea, select {
   html:focus-within {
     scroll-behavior: auto;
   }
-
   *, *::before, *::after {
     -webkit-animation-duration: 0.01ms !important;
             animation-duration: 0.01ms !important;
@@ -298,8 +296,21 @@ input, button, textarea, select {
     scroll-behavior: auto !important;
   }
 }
+
 html {
   background-color: #FFF;
+}
+
+#pageWrapper {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
+  position: relative;
+  min-height: 100vh;
 }
 
 .wrapper {
@@ -320,17 +331,21 @@ button {
   -webkit-transition: 0.3s;
   transition: 0.3s;
 }
+
 button:hover, button:focus {
   background-color: #4169E1;
 }
+
 button.themeToggle {
   letter-spacing: 0.2rem;
   padding: 0 10px 0 10px;
 }
+
 button.themeToggle:hover, button.themeToggle:focus {
   color: #000;
   background-color: #e7930b;
 }
+
 button.searchButton {
   width: 20%;
   border-radius: 25px;
@@ -376,9 +391,11 @@ p {
   letter-spacing: 0.05rem;
   margin: 0 0 10px 0;
 }
+
 p.plot {
   font-size: 1rem;
 }
+
 p.gridItem {
   font-size: 0.75rem;
   line-height: 2rem;
@@ -395,10 +412,12 @@ a {
   -webkit-transition: 0.3s;
   transition: 0.3s;
 }
+
 a.developer {
   font-family: "Allerta", sans-serif;
   font-size: 0.8rem;
 }
+
 a.developer:hover, a.developer:focus {
   display: inline-block;
   color: #000;
@@ -410,6 +429,7 @@ header {
   background-color: #1E90FF;
   color: #FFF;
 }
+
 header .headerFlexContainer {
   display: -webkit-box;
   display: -ms-flexbox;
@@ -421,11 +441,13 @@ header .headerFlexContainer {
       -ms-flex-align: center;
           align-items: center;
 }
+
 header .headerFlexContainer nav {
   display: inherit;
   width: 30vw;
   max-width: 300px;
 }
+
 header .headerFlexContainer nav ul {
   display: inherit;
   -webkit-box-align: center;
@@ -450,6 +472,7 @@ form {
           align-items: center;
   position: relative;
 }
+
 form input {
   padding: 5px 10px;
   width: 100%;
@@ -479,6 +502,7 @@ section.intro {
   -ms-flex-wrap: wrap;
       flex-wrap: wrap;
 }
+
 .results li {
   -webkit-box-flex: calc(25% - 20px);
       -ms-flex: calc(25% - 20px);
@@ -502,39 +526,74 @@ section.intro {
       -ms-flex-pack: justify;
           justify-content: space-between;
 }
+
 .results li:hover {
   background-color: #4169E1;
 }
+
 .results h3 {
   text-align: center;
 }
+
 .results img {
   min-height: 350px;
+  min-width: -webkit-fit-content;
+  min-width: -moz-fit-content;
+  min-width: fit-content;
+  border-radius: 20px;
+}
+
+.spacer {
+  height: 6rem;
+  width: 100%;
 }
 
 footer {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
   background-color: #1E90FF;
   color: #FFF;
   padding: 2% 0;
+  position: absolute;
+  bottom: 0;
   width: 100%;
+  height: 6rem;
 }
+
 footer .footerGridContainer {
+  position: relative;
+  -ms-grid-row-align: center;
+      align-self: center;
+  margin: 0 auto;
+  display: -ms-grid;
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  -ms-grid-columns: 1fr 1fr;
+      grid-template-columns: 1fr 1fr;
   justify-items: center;
   -webkit-box-align: end;
       -ms-flex-align: end;
           align-items: flex-end;
 }
+
 footer .footerGridContainer .gridItem1 {
-  grid-column: 1/-1;
+  grid-column: 1 / -1;
 }
+
 footer .footerGridContainer .gridItem2 {
-  grid-area: 2/1/3/2;
+  -ms-grid-row: 2;
+  -ms-grid-row-span: 1;
+  -ms-grid-column: 1;
+  -ms-grid-column-span: 1;
+  grid-area: 2 / 1 / 3 / 2;
 }
+
 footer .footerGridContainer .gridItem3 {
-  grid-area: 2/2/3/-1;
+  -ms-grid-row: 2;
+  -ms-grid-row-span: 1;
+  grid-area: 2 / 2 / 3 / -1;
 }
+
 footer .footerGridContainer .gridItem {
   margin: 0;
 }


### PR DESCRIPTION
DONE:
1) Search:
1a) Provide a workaround for `q` incompatibility with `order_by` and `sort` params.
1b) Provide a workaround to remove NSFW material since `sfw` param doesn't work with Jikan v4.
1c) Limit result number to 12 for best display.
2) Adjust footer:
2a) Make footerGridContainer into a flex item to eliminate the bottom gap.
2b) Add an empty div with the width of the footer above the footer to separate the result section and the footer.
2c) Adding a pageWrapper div to make all of this work.
3) Remove searched results upon firing a new search.

NOT DONE:
1) Search by title:
- Not possible with the current `q` param design. `q` loses functionality when migrating from v3 to v4. This prevents the API to fetch references by object.property.
2) Recommendation:
- Current recommendation is a direct scrape from the MAL website. It is possible to provide it as a separate section. However, initial examination shows that its value fluctuates widely (to including NSFW materials).
- It can't be called by genres, airTime, broadcasting... (lost functionality due to migration).

SUGGESTION:
- Rewrite the description of the app.
- Provide some insights regarding the API shortcoming.